### PR TITLE
delete 'default' in asyncActionUtils to fix error

### DIFF
--- a/src/asyncActionUtils.jsx
+++ b/src/asyncActionUtils.jsx
@@ -1,4 +1,4 @@
-export default function createAsyncDispatcher(type, promiseFn) {
+export function createAsyncDispatcher(type, promiseFn) {
   const SUCCESS = `${type}_SUCCESS`;
   const ERROR = `${type}_ERROR`;
 


### PR DESCRIPTION
DELETE 'default' from createAsyncDispatcher in asyncActionUtils.jsx to fix compile error